### PR TITLE
Access Shim: fix Cloudflare Access JWT verification (JWKS host vs issuer)

### DIFF
--- a/docs/HANDOFF-access-jwks-vs-iss.md
+++ b/docs/HANDOFF-access-jwks-vs-iss.md
@@ -1,0 +1,106 @@
+# Handoff: Cloudflare Access JWKS-host ≠ token-iss bug in `AccessJwtVerifier.forTeam`
+
+**For:** the agent owning tools→console Access auth (single quarterback).
+**From:** the agent that fixed the *same* bug in monitoring.buoy.fish (Grafana).
+**Date:** 2026-06-16. **Status:** console side NOT changed — diagnosis + fix design only.
+
+> **UPDATE 2026-06-16 (supersedes the `royal-waterfall` claims below):** the
+> fix shipped (`AccessJwtVerifier.forTeam(issuerDomain, jwksDomain, audience)` +
+> `helium.cf.access.jwks.domain`), AND Cloudflare has since completed the team
+> rename. Console Access tokens now carry `iss=https://buoy-fish.cloudflareaccess.com`
+> signed by buoy-fish keys — issuer AND JWKS are both **buoy-fish**, so there is
+> **no live split today**. The `royal-waterfall` references below are historical
+> (the transient migration state); both config defaults and the box are now
+> `buoy-fish`. The two-knob decoupling was kept as defense in case the labels
+> ever diverge again. The monitoring/Grafana box may still wrongly pin
+> `royal-waterfall` and need the same correction — verify by decoding a live token.
+
+---
+
+## TL;DR
+
+This Cloudflare Access account has **two team-domain labels for the same team**:
+
+| Label | Reachable? | Role |
+|---|---|---|
+| `royal-waterfall-9e8e.cloudflareaccess.com` | **certs/login 404** | original auto-assigned name; **still stamped into every token's `iss`** |
+| `buoy-fish.cloudflareaccess.com` | **200** | custom domain added later; **only host serving the JWKS/signing keys** |
+
+So any Access-JWT validator must use **JWKS host = `buoy-fish`** and **expected `iss` = `royal-waterfall`** — *different domains, on purpose*. Code that derives the JWKS URL from the issuer (or assumes one team domain for both) **cannot fetch keys → 404 → all verification fails.**
+
+`AccessJwtVerifier.forTeam()` does exactly that and is the latent landmine. It is **not breaking today** because the console shim is *match-only* (signature validation is deferred tier-3 per `sign.buoy.fish/docs/adr/0003`). It **will** break the instant tier-3 / real JWKS verification is switched on.
+
+## Evidence (already gathered — don't re-derive)
+
+- `curl https://royal-waterfall-9e8e.cloudflareaccess.com/cdn-cgi/access/certs` → **404**.
+- `curl https://buoy-fish.cloudflareaccess.com/cdn-cgi/access/certs` → **200** (kids `d80d1eed…`, `0da27153…`).
+- `https://buoy-fish.cloudflareaccess.com/.well-known/openid-configuration` → `issuer: https://buoy-fish…`, `jwks_uri: https://buoy-fish…/cdn-cgi/access/certs`. **NB: discovery's `issuer` disagrees with reality.**
+- A **live decoded `Cf-Access-Jwt-Assertion`** (captured off `monitoring` box `lo:3000`, plaintext nginx→app) carried: `iss = https://royal-waterfall-9e8e.cloudflareaccess.com`, `aud = ["7cacba06…c44b"]`, `type = app`, `email = jameson@buoy.fish`. Signed by kid `0da27153…`, which lives in **buoy-fish's** JWKS — i.e. **royal-waterfall-iss token verifies against buoy-fish keys** (same account keys; only the domain label is stale). Trust the decoded token, not the discovery doc.
+- To re-verify a live `iss` yourself (no Access login needed; nginx→app is plaintext on loopback): `sudo tcpdump -i lo -w /tmp/c.pcap 'tcp dst port <appPort>'`, then `strings` for `Cf-Access-Jwt-Assertion:` and base64url-decode segment 2.
+
+## The bug, precisely
+
+`src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java`:
+
+```java
+public static AccessJwtVerifier forTeam(String teamDomain, String audience) throws Exception {
+    String iss = "https://" + teamDomain;
+    JWKSource<SecurityContext> remote = JWKSourceBuilder
+            .create(new URL(iss + "/cdn-cgi/access/certs"))   // <-- JWKS host derived from iss
+            .retrying(true)
+            .build();
+    return new AccessJwtVerifier(remote, iss, audience);
+}
+```
+
+`src/main/resources/application.properties:150`: `helium.cf.access.team.domain.default=royal-waterfall-9e8e.cloudflareaccess.com`.
+With that value, the JWKS URL resolves to the 404 host. **A property-only flip to `buoy-fish` does NOT fix it** — it would fix JWKS but wrongly set `iss=buoy-fish`, and live tokens are `iss=royal-waterfall`. (This is the exact trap I fell into on the Grafana side before decoding a live token.)
+
+Note the package-private constructor `AccessJwtVerifier(JWKSource, issuer, audience)` is **already decoupled** — only the `forTeam` factory couples the two. The existing test uses the constructor with an injected JWKSource, so it passes despite the bug.
+
+## Suggested fix (decouple JWKS host from issuer)
+
+Mirror the monitoring fix (merged-pending: **buoy-fish/monitoring PR #6** — keep `iss` royal-waterfall, point JWKS at buoy-fish, with a comment documenting the split).
+
+1. **New config**, following the existing `*.default` + external-override pattern in `ConsoleConfig.java` (~line 1024, the "Cloudflare Access Shim" block) and `application.properties`:
+   - `helium.cf.access.jwks.domain.default=buoy-fish.cloudflareaccess.com`
+   - `helium.cf.access.jwks.domain:` (external override, empty default)
+   - Add fields `cfAccessJwksDomainDefault` / `cfAccessJwksDomainExternal` + a `getCfAccessJwksDomain()` getter following the same precedence as `getCfAccessTeamDomain()`.
+2. **`forTeam` takes the JWKS host separately:**
+   ```java
+   public static AccessJwtVerifier forTeam(String issuerDomain, String jwksDomain, String audience) throws Exception {
+       String iss = "https://" + issuerDomain;
+       URL jwksUrl = new URL("https://" + jwksDomain + "/cdn-cgi/access/certs");
+       JWKSource<SecurityContext> remote = JWKSourceBuilder.create(jwksUrl).retrying(true).build();
+       return new AccessJwtVerifier(remote, iss, audience);
+   }
+   ```
+   Keep the issuer domain (`royal-waterfall`) as the source of `iss`; jwksDomain defaults to `buoy-fish`.
+3. **Update the one caller** `service/AccessShimSetup.java:34`:
+   `AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(), config.getCfAccessJwksDomain(), audience);`
+4. **Leave `team.domain.default` = `royal-waterfall-9e8e…`** (it is the *issuer*, and it's correct).
+
+## Tests (TDD — write the failing one first)
+
+`src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java` already has `ISSUER = https://royal-waterfall-9e8e…` and a "wrong issuer is rejected" case via the injected-JWKSource constructor — keep those.
+- The new behavior to pin is in `forTeam`: **the certs URL is built from the jwks-domain arg, independent of the issuer arg.** `JWKSourceBuilder.create(URL)` is lazy (no network at construction), but asserting the URL is awkward. Cleanest: extract a tiny `static URL certsUrl(String jwksDomain)` (or `String`) helper and unit-test `certsUrl("buoy-fish.cloudflareaccess.com")` == `https://buoy-fish.cloudflareaccess.com/cdn-cgi/access/certs`, decoupled from issuer. Write that test red against current code (where the URL comes from `iss`), then refactor green.
+- Keep an end-to-end-ish test: token with `iss = royal-waterfall`, signed by an in-memory keyset injected as the JWKSource, verified by `new AccessJwtVerifier(localKeys, "https://royal-waterfall-9e8e…", AUDIENCE)` → passes; `iss = buoy-fish` or `some-other-team` → rejected.
+
+## Cautions / repo state
+
+- **Remotes:** `origin` = `git@github.com:buoy-fish/helium-chirpstack-community.git` (PR here). `community`/`upstream` = `disk91/helium-chirpstack-community` — **do NOT push there**; this team-domain config is buoy-specific and must not go upstream.
+- **Untracked files present from other agents** (`TODO.md`, `docs/HPR_RECONCILIATION_PLAN.md`, `docs/drift-matrix.md`, `docs/join-captures/`, `lorawan-analyzer/`, `scripts/`). Don't sweep them into your commit; branch + `git add` only the auth files. Consider a worktree to isolate.
+- **`aud`:** the console default `helium.cf.access.audience.default=` is **empty**. The live token's `aud` is `["7cacba06…c44b"]` (an array). Decide whether to pin audience (Grafana skips aud because Nimbus/Grafana compare scalar-vs-array — Nimbus' `DefaultJWTClaimsVerifier` *does* handle aud, but confirm array handling). Out of scope for the JWKS/iss fix but worth a glance while you're in here.
+- **Stale docs to fix while here:** `docs/HANDOFF.md` (tools repo) and worktrees document the JWKS at the dead `royal-waterfall…/certs` — correct them. `sign.buoy.fish/docs/adr/0003` already *notes* the stale-ref discrepancy.
+
+## Suggested skills
+
+- `tdd` — red-green-refactor for the `forTeam` / `certsUrl` change (one failing test first).
+- `verify` — exercise the shim end-to-end once tier-3 verification is enabled (replay a live token, expect a minted ChirpStack session, not a 401).
+- `code-review` — before the PR.
+
+## Cross-references (don't duplicate — read these)
+
+- Memory `access-jwks-host-differs-from-iss` (in this Claude project's memory dir) — the canonical statement of the gotcha + which systems are affected.
+- Monitoring precedent: **buoy-fish/monitoring PR #6** (diff + reasoning); already hotfixed live on the monitoring box.
+- ADRs: `sign.buoy.fish/docs/adr/0002` (Access identity consumption), `0003` (accounting/console Access shim, match-only, deferred tier-3).

--- a/src/main/java/eu/heliumiot/console/ConsoleConfig.java
+++ b/src/main/java/eu/heliumiot/console/ConsoleConfig.java
@@ -1027,9 +1027,10 @@ public class ConsoleConfig {
     @Value ("${helium.cf.access.team.domain:}")
     private String cfAccessTeamDomainExternal;
 
-    // JWKS host — DIFFERENT label of the same team than the issuer above:
-    // tokens are stamped iss=team.domain (royal-waterfall) but signed by keys
-    // served only at this host (buoy-fish). See HANDOFF-access-jwks-vs-iss.
+    // JWKS host — its own knob, separate from the issuer (team.domain) above so
+    // the two can differ during a Cloudflare team-domain migration (iss on the
+    // old label, keys only on the new). Currently IDENTICAL — both buoy-fish,
+    // the rename being complete. See docs/HANDOFF-access-jwks-vs-iss.md.
     @Value ("${helium.cf.access.jwks.domain.default}")
     private String cfAccessJwksDomainDefault;
 

--- a/src/main/java/eu/heliumiot/console/ConsoleConfig.java
+++ b/src/main/java/eu/heliumiot/console/ConsoleConfig.java
@@ -1027,6 +1027,15 @@ public class ConsoleConfig {
     @Value ("${helium.cf.access.team.domain:}")
     private String cfAccessTeamDomainExternal;
 
+    // JWKS host — DIFFERENT label of the same team than the issuer above:
+    // tokens are stamped iss=team.domain (royal-waterfall) but signed by keys
+    // served only at this host (buoy-fish). See HANDOFF-access-jwks-vs-iss.
+    @Value ("${helium.cf.access.jwks.domain.default}")
+    private String cfAccessJwksDomainDefault;
+
+    @Value ("${helium.cf.access.jwks.domain:}")
+    private String cfAccessJwksDomainExternal;
+
     @Value ("${helium.cf.access.audience.default}")
     private String cfAccessAudienceDefault;
 
@@ -1051,6 +1060,13 @@ public class ConsoleConfig {
     public String getCfAccessTeamDomain() {
         if (!cfAccessTeamDomainExternal.isEmpty()) return cfAccessTeamDomainExternal;
         return cfAccessTeamDomainDefault;
+    }
+
+    /** Host serving the Access signing keys (JWKS) — see field comment; this
+     *  is intentionally NOT the same as the issuer/team domain. */
+    public String getCfAccessJwksDomain() {
+        if (!cfAccessJwksDomainExternal.isEmpty()) return cfAccessJwksDomainExternal;
+        return cfAccessJwksDomainDefault;
     }
 
     /** The Access application's aud tag; empty = Shim disabled. */

--- a/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
@@ -49,13 +49,27 @@ public class AccessJwtVerifier {
     }
 
     /**
+     * The Cloudflare Access JWKS (certs) endpoint for a team label. Kept
+     * deliberately separate from the issuer: on the buoy account the signing
+     * keys are served ONLY at the buoy-fish label, while every token is
+     * stamped with the (404-on-certs) royal-waterfall issuer. Deriving this
+     * URL from the issuer is the latent bug — see docs/HANDOFF-access-jwks-vs-iss.
+     */
+    static String certsUrl(String jwksDomain) {
+        return "https://" + jwksDomain + "/cdn-cgi/access/certs";
+    }
+
+    /**
      * Production wiring: remote JWKS with Nimbus' built-in caching and
      * rate-limiting, so Cloudflare key rotation is handled transparently.
+     * issuerDomain (the token's {@code iss}) and jwksDomain (where the signing
+     * keys live) are different labels of the SAME team on this account, so they
+     * are passed separately — never derive one from the other.
      */
-    public static AccessJwtVerifier forTeam(String teamDomain, String audience) throws Exception {
-        String iss = "https://" + teamDomain;
+    public static AccessJwtVerifier forTeam(String issuerDomain, String jwksDomain, String audience) throws Exception {
+        String iss = "https://" + issuerDomain;
         JWKSource<SecurityContext> remote = JWKSourceBuilder
-                .create(new URL(iss + "/cdn-cgi/access/certs"))
+                .create(new URL(certsUrl(jwksDomain)))
                 .retrying(true)
                 .build();
         return new AccessJwtVerifier(remote, iss, audience);

--- a/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
@@ -50,10 +50,10 @@ public class AccessJwtVerifier {
 
     /**
      * The Cloudflare Access JWKS (certs) endpoint for a team label. Kept
-     * deliberately separate from the issuer: on the buoy account the signing
-     * keys are served ONLY at the buoy-fish label, while every token is
-     * stamped with the (404-on-certs) royal-waterfall issuer. Deriving this
-     * URL from the issuer is the latent bug — see docs/HANDOFF-access-jwks-vs-iss.
+     * deliberately separate from the issuer: during a Cloudflare team-domain
+     * migration the token's iss can be one label while the signing keys are
+     * served only at another (the other label's /certs returns 404). Deriving
+     * this URL from the issuer is the latent bug — see docs/HANDOFF-access-jwks-vs-iss.
      */
     static String certsUrl(String jwksDomain) {
         return "https://" + jwksDomain + "/cdn-cgi/access/certs";

--- a/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
@@ -27,11 +27,13 @@ public class AccessShimSetup {
             log.info("Access Shim disabled — helium.cf.access.audience is not set");
             audience = DISABLED_SENTINEL;
         } else {
-            log.info("Access Shim enabled for team {} (aud {}…)",
-                    config.getCfAccessTeamDomain(), audience.substring(0, Math.min(8, audience.length())));
+            log.info("Access Shim enabled for team {} (jwks {}, aud {}…)",
+                    config.getCfAccessTeamDomain(), config.getCfAccessJwksDomain(),
+                    audience.substring(0, Math.min(8, audience.length())));
         }
         AccessJwtVerifier verifier =
-                AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(), audience);
+                AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(),
+                        config.getCfAccessJwksDomain(), audience);
         if (config.getChirpstackApiSecret() == null || config.getChirpstackApiSecret().isBlank()) {
             log.warn("chirpstack.api.secret not set — walk-in sessions will carry no "
                     + "chirpstack bearer and device/gateway views will prompt for login");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,11 +147,13 @@ helium.stats.report.enable.default=true
 # Cloudflare Access Shim (walk-in SSO, buoy-services ADR-0002).
 # audience = the Access application's aud tag; empty disables the Shim
 # (the /sign/access endpoint then rejects every exchange).
-# team.domain = the token issuer (iss). jwks.domain = the host that actually
-# serves the signing keys. On the buoy account these are two labels of one
-# team and must differ: royal-waterfall's /certs is 404, buoy-fish's is 200.
-# See docs/HANDOFF-access-jwks-vs-iss.md.
-helium.cf.access.team.domain.default=royal-waterfall-9e8e.cloudflareaccess.com
+# team.domain = the token issuer (iss). jwks.domain = the host serving the
+# signing keys (JWKS). Kept as two knobs because during a Cloudflare team-domain
+# migration they can differ (the iss keeps an old label while keys move to the
+# new one, whose /certs the old label 404s) — see docs/HANDOFF-access-jwks-vs-iss.md.
+# Measured live 2026-06-16: console Access tokens carry iss=buoy-fish and the
+# keys are at buoy-fish, so both default to buoy-fish.
+helium.cf.access.team.domain.default=buoy-fish.cloudflareaccess.com
 helium.cf.access.jwks.domain.default=buoy-fish.cloudflareaccess.com
 helium.cf.access.audience.default=
 helium.cf.access.session.ms.default=86400000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,6 +147,11 @@ helium.stats.report.enable.default=true
 # Cloudflare Access Shim (walk-in SSO, buoy-services ADR-0002).
 # audience = the Access application's aud tag; empty disables the Shim
 # (the /sign/access endpoint then rejects every exchange).
+# team.domain = the token issuer (iss). jwks.domain = the host that actually
+# serves the signing keys. On the buoy account these are two labels of one
+# team and must differ: royal-waterfall's /certs is 404, buoy-fish's is 200.
+# See docs/HANDOFF-access-jwks-vs-iss.md.
 helium.cf.access.team.domain.default=royal-waterfall-9e8e.cloudflareaccess.com
+helium.cf.access.jwks.domain.default=buoy-fish.cloudflareaccess.com
 helium.cf.access.audience.default=
 helium.cf.access.session.ms.default=86400000

--- a/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
@@ -116,10 +116,10 @@ public class AccessJwtVerifierTest {
 
     @Test
     void certsUrlFollowsJwksDomainNotIssuer() {
-        // This Cloudflare account has two labels for one team: tokens are
-        // stamped iss=royal-waterfall-9e8e… (whose /certs is 404), but are
-        // signed by keys served ONLY at buoy-fish… So the JWKS/certs URL must
-        // be built from the jwks domain, independently of the issuer domain.
+        // The certs URL must be built from the JWKS domain, independently of
+        // the issuer: during a Cloudflare team-domain migration the token iss
+        // can be one label while the signing keys are served only at another
+        // (the other label's /certs returns 404). This pins that decoupling.
         assertEquals(
                 "https://buoy-fish.cloudflareaccess.com/cdn-cgi/access/certs",
                 AccessJwtVerifier.certsUrl("buoy-fish.cloudflareaccess.com"));

--- a/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
@@ -113,4 +113,15 @@ public class AccessJwtVerifierTest {
         assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(""));
         assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(null));
     }
+
+    @Test
+    void certsUrlFollowsJwksDomainNotIssuer() {
+        // This Cloudflare account has two labels for one team: tokens are
+        // stamped iss=royal-waterfall-9e8e… (whose /certs is 404), but are
+        // signed by keys served ONLY at buoy-fish… So the JWKS/certs URL must
+        // be built from the jwks domain, independently of the issuer domain.
+        assertEquals(
+                "https://buoy-fish.cloudflareaccess.com/cdn-cgi/access/certs",
+                AccessJwtVerifier.certsUrl("buoy-fish.cloudflareaccess.com"));
+    }
 }


### PR DESCRIPTION
Fixes the tools→console Cloudflare Access walk-in SSO, which 403'd on every real token.

- Decouple the JWKS host from the token issuer in `AccessJwtVerifier.forTeam(issuerDomain, jwksDomain, audience)` (new `helium.cf.access.jwks.domain`), so the certs URL is no longer derived from `iss`.
- Live-measured issuer is `buoy-fish` (the doc's `royal-waterfall` was a stale pre-rename capture); both defaults set to `buoy-fish`.
- Unit test pins the `certsUrl` decoupling. Track + correct `docs/HANDOFF-access-jwks-vs-iss.md`.

Deployed and verified live on the box (`Access walk-in granted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)