### PR TITLE
console front: default embedded ChirpStack to a configured tenant on fresh session

### DIFF
--- a/nuxt/console/nuxt.config.js
+++ b/nuxt/console/nuxt.config.js
@@ -9,6 +9,10 @@ export default {
   publicRuntimeConfig: {
     apiHost:process.env.API_HOST || '',
     chirpstackHost:(process.env.CHIRPSTACK_HOST || '' )+'/' || '/',
+    // Tenant the embedded ChirpStack UI should default to on a fresh session
+    // (empty = no default, i.e. stock behaviour). Set via DEFAULT_TENANT_ID at
+    // build time so the id is never hardcoded into the public fork.
+    defaultTenant:process.env.DEFAULT_TENANT_ID || '',
     consoleName:process.env.CONSOLE_NAME || 'HeliumConsole',
     dcbalanceEndpoint:(process.env.API_HOST || '')+'/console/1.0/tenant/balance',
     signupEndpoint:(process.env.API_HOST || '')+'/console/1.0/sign/up',

--- a/nuxt/console/pages/front/login.vue
+++ b/nuxt/console/pages/front/login.vue
@@ -196,6 +196,15 @@ export default Vue.extend({
         this.$store.commit('setConsoleBearer', '');
         this.$store.commit('setUserAdmin',false);
 
+        // Default the embedded ChirpStack UI to our primary tenant on a fresh
+        // session. ChirpStack keeps the active tenant in localStorage['tenantId'];
+        // seeding it here (config-driven, never hardcoded) makes a clean
+        // walk-in/login land on the configured tenant instead of whatever
+        // ChirpStack sorts first. An existing selection is left untouched.
+        if (this.$config.defaultTenant && !localStorage.getItem('tenantId')) {
+            localStorage.setItem('tenantId', this.$config.defaultTenant);
+        }
+
         // Cloudflare Access walk-in (buoy-services ADR-0002): behind the
         // tunnel, every request carries Cf-Access-Jwt-Assertion — try
         // exchanging it for a console session before showing the form.


### PR DESCRIPTION
On a fresh session the embedded ChirpStack UI lands on whatever tenant it sorts first (SCMG before buoy). Seed `localStorage['tenantId']` with a build-time `DEFAULT_TENANT_ID` on login when none is set, so a clean walk-in/login opens on the configured (buoy) tenant. Existing selections kept; empty config = stock behaviour; id stays out of the public fork.

Deployed and verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)