### PR TITLE
[DRAFT] Capture prod box branch buoy/mqtt-auth-and-expose for reconciliation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM eclipse-temurin:24-jre
 COPY ./build/libs/Console-0.0.1-SNAPSHOT.jar Console.jar
 COPY configuration.properties .
 ENTRYPOINT ["java","-jar","/Console.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -34,14 +34,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation group: 'org.eclipse.paho', name:'org.eclipse.paho.client.mqttv3', version: '1.2.5'
-	implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.15.4'
-	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
+	implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.16.2'
+	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.9'
 	implementation group: 'redis.clients', name: 'jedis', version: '5.1.5'
-	implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.25.5'
+	implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.25.8'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
-	implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.81'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.7'
-	implementation group: 'org.flywaydb', name: 'flyway-core', version: '11.11.2'
+	implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.83'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.13.0'
+	// Cloudflare Access Shim (ADR-0002): RS256 validation of
+	// Cf-Access-Jwt-Assertion against the team's remote JWKS. jjwt has no
+	// remote-JWKS support; Nimbus is what Spring Security wraps internally.
+	implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
+	implementation group: 'org.flywaydb', name: 'flyway-core', version: '11.20.2'
 	implementation group: 'com.stripe', name:'stripe-java', version:'29.5.0'
 	implementation group: 'org.apache.pdfbox', name:'pdfbox', version:'3.0.5'
 	implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.29.2'
@@ -49,12 +53,12 @@ dependencies {
 	implementation group: 'io.grpc', name: 'grpc-stub', version:'1.69.0'
 	compileOnly group:'org.apache.tomcat', name:'tomcat-annotations-api', version: '11.0.11'
 
-	runtimeOnly group: 'io.grpc', name:'grpc-netty-shaded', version: '1.69.0'
-	runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.7'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.7'
-    runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '11.11.2'
-    //testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly group: 'io.grpc', name:'grpc-netty-shaded', version: '1.78.0'
+	runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.9'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.13.0'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.13.0'
+    runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '11.20.2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 

--- a/chirpstack/configuration/chirpstack-gateway-bridge-as923-2/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-as923-2/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="as923_2/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-as923-3/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-as923-3/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="as923_3/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-as923-4/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-as923-4/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="as923_4/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-as923/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-as923/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="as923/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-au915-1/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-au915-1/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="au915_1/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-eu868/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-eu868/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="eu868/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-in865/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-in865/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="in865/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-kr920/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-kr920/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="kr920/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack-gateway-bridge-us915/chirpstack-gateway-bridge.toml
+++ b/chirpstack/configuration/chirpstack-gateway-bridge-us915/chirpstack-gateway-bridge.toml
@@ -3,8 +3,8 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="gateway"
+password="buoy"
 
 [integration.mqtt]
 event_topic_template="us915_1/gateway/{{ .GatewayID }}/event/{{ .EventType }}"

--- a/chirpstack/configuration/chirpstack/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack/chirpstack.toml
@@ -19,7 +19,7 @@
   #  * require - Always SSL (skip verification)
   #  * verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
   #  * verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
-  dsn="postgres://chirpstack:@DBPASSWORD@@$POSTGRESQL_HOST/chirpstack?sslmode=disable"
+  dsn="postgres://chirpstack:c1a0f38be7bc2d2a4db3@$POSTGRESQL_HOST/chirpstack?sslmode=disable"
 
   # Max open connections.
   #
@@ -70,11 +70,11 @@
 
   # Network identifier (NetID, 3 bytes) encoded as HEX (e.g. 010203).
   # Usually 000024 or 00003C for Helium
-  net_id="@NETID@"
+  net_id="00003C"
 
   # List devAddr range you own
   #dev_addr_prefixes=["FC014C30/28","FC014C50/28","FC014C10/29"]
-  dev_addr_prefixes=["@ADDRRANGE@"]
+  dev_addr_prefixes=["78000190/29"]
 
   # Enabled regions.
   #
@@ -101,13 +101,6 @@
   # must be less than the (first) receive-window.
   deduplication_delay="350ms"
 
-  # Custom ADR plugins.
-  #
-  # The custom ADR plugin must be implemented in JavaScript. For an example
-  # skeleton, please see:
-  # https://github.com/chirpstack/chirpstack/blob/master/examples/adr_plugins/plugin_skeleton.js
-  adr_plugins=[ "/etc/chirpstack/adr/no_adr.js", "/etc/chirpstack/adr/force_dr1_adr.js" ]
-
 # API interface configuration.
 [api]
 
@@ -120,7 +113,7 @@
   # is never exposed. Changing this secret will invalidate all login and API
   # tokens. The following command can be used to generate a random secret:
   #   openssl rand -base64 32
-  secret="@CHIRPSECRET@"
+  secret="GKPv/wiRBZbzVcYRtMZnOUQlJOMoUpidaJ7s69WvR/w="
 
 
 [integration]
@@ -128,6 +121,8 @@
 
   [integration.mqtt]
     server="tcp://$MQTT_BROKER_HOST:1883/"
+    username="gateway"
+    password="buoy"
     json=true
 
 [gateway]

--- a/chirpstack/configuration/chirpstack/region_as923.toml
+++ b/chirpstack/configuration/chirpstack/region_as923.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_as923_2.toml
+++ b/chirpstack/configuration/chirpstack/region_as923_2.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_as923_3.toml
+++ b/chirpstack/configuration/chirpstack/region_as923_3.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_as923_4.toml
+++ b/chirpstack/configuration/chirpstack/region_as923_4.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_0.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_0.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_1.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_1.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_2.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_2.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_3.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_3.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_4.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_4.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_5.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_5.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_6.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_6.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_au915_7.toml
+++ b/chirpstack/configuration/chirpstack/region_au915_7.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_0.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_0.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_1.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_1.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_10.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_10.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_11.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_11.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_2.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_2.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_3.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_3.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_4.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_4.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_5.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_5.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_6.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_6.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_7.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_7.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_8.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_8.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn470_9.toml
+++ b/chirpstack/configuration/chirpstack/region_cn470_9.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_cn779.toml
+++ b/chirpstack/configuration/chirpstack/region_cn779.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_eu433.toml
+++ b/chirpstack/configuration/chirpstack/region_eu433.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_eu868.toml
+++ b/chirpstack/configuration/chirpstack/region_eu868.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_in865.toml
+++ b/chirpstack/configuration/chirpstack/region_in865.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_ism2400.toml
+++ b/chirpstack/configuration/chirpstack/region_ism2400.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_kr920.toml
+++ b/chirpstack/configuration/chirpstack/region_kr920.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_ru864.toml
+++ b/chirpstack/configuration/chirpstack/region_ru864.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_0.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_0.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_1.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_1.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_2.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_2.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_3.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_3.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_4.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_4.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_5.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_5.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_6.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_6.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/chirpstack/region_us915_7.toml
+++ b/chirpstack/configuration/chirpstack/region_us915_7.toml
@@ -37,10 +37,10 @@
         server="tcp://$MQTT_BROKER_HOST:1883"
 
         # Connect with the given username (optional)
-        username=""
+        username="gateway"
 
         # Connect with the given password (optional)
-        password=""
+        password="buoy"
 
         # Quality of service level
         #

--- a/chirpstack/configuration/helium/configuration.properties
+++ b/chirpstack/configuration/helium/configuration.properties
@@ -24,8 +24,8 @@ helium.transfer.enable=true
 
 # MQTT
 mqtt.server=tcp://mosquitto:1883
-mqtt.login=
-mqtt.password=
+mqtt.login=@MQTTLOGIN@
+mqtt.password=@MQTTPASSWORD@
 mqtt.id=
 
 ## PostgreSQL
@@ -43,6 +43,11 @@ spring.data.redis.ssl.enabled=false
 spring.data.redis.timeout=60000
 spring.data.redis.consumerGroup=cgroup_10
 spring.data.redis.consumer=consumer_0
+
+# Redis stream tuning - limit logs and reduce spam
+spring.data.redis.stream.maxlen=1000
+spring.data.redis.stream.consumer.backoff.ms=1000
+spring.data.redis.stream.consumer.enabled=true
 
 ## Helium GPRC
 helium.grpc.enable=true

--- a/chirpstack/configuration/mosquitto/mosquitto.conf
+++ b/chirpstack/configuration/mosquitto/mosquitto.conf
@@ -1,5 +1,6 @@
 listener 1883
-allow_anonymous true
+allow_anonymous false
+password_file /mosquitto/data/passwd
 persistent_client_expiration 15d
 autosave_interval 120
 persistence true

--- a/chirpstack/docker-compose.yml
+++ b/chirpstack/docker-compose.yml
@@ -236,7 +236,7 @@ services:
   mosquitto_exporter:
     image: sapcc/mosquitto-exporter:latest
     restart: unless-stopped
-    command: --endpoint tcp://mosquitto:1883
+    command: --endpoint tcp://mosquitto:1883 --user gateway --pass buoy
     ports:
       - 127.0.0.1:9101:9234
     depends_on:

--- a/chirpstack/docker-compose.yml
+++ b/chirpstack/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     logging: *logs
 
   chirpstack:
-    image: chirpstack/chirpstack:4.14.1
+    image: chirpstack/chirpstack:4.11.0
     command: -c /etc/chirpstack
     restart: unless-stopped
     volumes:
@@ -198,7 +198,7 @@ services:
     image: eclipse-mosquitto:2
     restart: unless-stopped
     ports:
-      - 127.0.0.1:1883:1883
+      - 0.0.0.0:1883:1883
     volumes:
       - /helium/configuration/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
       - /helium/mosquitto:/mosquitto/data

--- a/chirpstack/docker-compose.yml
+++ b/chirpstack/docker-compose.yml
@@ -201,6 +201,11 @@ services:
       - 0.0.0.0:1883:1883
     volumes:
       - /helium/configuration/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      # password_file + acl.conf were only in the container layer and vanished
+      # on recreate (2026-06-12 uplink outage: allow_anonymous false + missing
+      # pwfile = crash loop). Bind them so they survive future recreates.
+      - /helium/configuration/mosquitto/password_file:/mosquitto/config/password_file
+      - /helium/configuration/mosquitto/acl.conf:/mosquitto/config/acl.conf
       - /helium/mosquitto:/mosquitto/data
     logging: *logs
 

--- a/makeiteasy.sh
+++ b/makeiteasy.sh
@@ -415,7 +415,13 @@ fi
 
 
 # ready to run it !
+
+# Fix data directory permissions for containerized services
+# Grafana runs as UID 472, Prometheus runs as UID 65534 (nobody)
+chown -R 472:472 /helium/grafana/
+chown -R 65534:65534 /helium/prometheus/
 cecho "Installation completed"
+
 getPubKey
 cd /helium
 echo "The installation is completed, before being able to run it, you must request Helium Foundation"

--- a/makeiteasy.sh
+++ b/makeiteasy.sh
@@ -102,6 +102,19 @@ askSmtpConfig() {
 }
 
 
+
+MQTTLOGIN=""
+MQTTPASSWORD=""
+getMqttConfig() {
+  if [ "$MQTTLOGIN" == "" ] ; then
+    read -p "MQTT username for broker auth (default: gateway): " mqttlogin
+    MQTTLOGIN=${mqttlogin:-gateway}
+  fi
+  if [ "$MQTTPASSWORD" == "" ] ; then
+    MQTTPASSWORD=`openssl rand -hex 16`
+    echo "Generated MQTT password: $MQTTPASSWORD"
+  fi
+}
 DOMAIN=""
 PROTO=""
 FULLDOMAIN=""
@@ -363,6 +376,11 @@ if egrep "@DOMAIN@" /helium/configuration/helium/configuration.properties > /dev
   sed -i "s/@SMTPPORT@/$SMTPPORT/g" /helium/configuration/helium/configuration.properties
   sed -i "s/@SMTPUSER@/$SMTPUSER/g" /helium/configuration/helium/configuration.properties
   sed -i "s/@SMTPPASS@/$SMTPPASS/g" /helium/configuration/helium/configuration.properties
+  getMqttConfig
+  sed -i "s/@MQTTLOGIN@/$MQTTLOGIN/g" /helium/configuration/helium/configuration.properties
+  sed -i "s/@MQTTPASSWORD@/$MQTTPASSWORD/g" /helium/configuration/helium/configuration.properties
+  # Also set the password in mosquitto
+  docker exec helium-mosquitto-1 mosquitto_passwd -b /mosquitto/data/passwd $MQTTLOGIN $MQTTPASSWORD 2>/dev/null || true
 fi
 
 # build the companion

--- a/nuxt/console/nuxt.config.js
+++ b/nuxt/console/nuxt.config.js
@@ -9,6 +9,10 @@ export default {
   publicRuntimeConfig: {
     apiHost:process.env.API_HOST || '',
     chirpstackHost:(process.env.CHIRPSTACK_HOST || '' )+'/' || '/',
+    // Tenant the embedded ChirpStack UI should default to on a fresh session
+    // (empty = no default, i.e. stock behaviour). Set via DEFAULT_TENANT_ID at
+    // build time so the id is never hardcoded into the public fork.
+    defaultTenant:process.env.DEFAULT_TENANT_ID || '',
     consoleName:process.env.CONSOLE_NAME || 'HeliumConsole',
     dcbalanceEndpoint:(process.env.API_HOST || '')+'/console/1.0/tenant/balance',
     signupEndpoint:(process.env.API_HOST || '')+'/console/1.0/sign/up',

--- a/nuxt/console/nuxt.config.js
+++ b/nuxt/console/nuxt.config.js
@@ -104,7 +104,6 @@ export default {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/static/front/favicon.ico' }],
     script: [
       { src: 'https://js.stripe.com/v3/' },
-      { src: 'https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=fetch'},
       { src: 'https://unpkg.com/@mapbox/leaflet-pip@latest/leaflet-pip.js' },
     ],
   },

--- a/nuxt/console/pages/front/login.vue
+++ b/nuxt/console/pages/front/login.vue
@@ -207,6 +207,11 @@ export default Vue.extend({
         try {
             const resp = await this.$axios.get((process.env.API_HOST || '')+'/console/1.0/sign/access');
             if ( resp != null && resp.data != null && resp.data.consoleBearer ) {
+                // store BOTH tokens exactly as password login does — the SPA
+                // talks to chirpstack directly with chirpstackBearer
+                let chBearer = resp.data.chirpstackBearer;
+                this.$store.commit('setChirpstackBearer', chBearer);
+                localStorage.setItem("token", chBearer);
                 this.$store.commit('setConsoleBearer', resp.data.consoleBearer);
                 this.$store.commit('setUserAdmin', resp.data.admin);
                 await this.$auth.setUserToken(resp.data.consoleBearer);

--- a/nuxt/console/pages/front/login.vue
+++ b/nuxt/console/pages/front/login.vue
@@ -190,11 +190,31 @@ export default Vue.extend({
             this.$router.push('/front/lostpass');
         }
     },
-    mounted() {
+    async mounted() {
         this.$store.commit('setChirpstackBearer', '');
         localStorage.setItem('token', '');
         this.$store.commit('setConsoleBearer', '');
         this.$store.commit('setUserAdmin',false);
+
+        // Cloudflare Access walk-in (buoy-services ADR-0002): behind the
+        // tunnel, every request carries Cf-Access-Jwt-Assertion — try
+        // exchanging it for a console session before showing the form.
+        // 404 = cleared the wall but no console account (match-only);
+        // 403 = no/invalid Access JWT (e.g. local dev). Either way we
+        // fall back silently to the normal login form. Walk-in sessions
+        // carry no chirpstackBearer — only the chirpstack migration
+        // screen needs one; password login covers that case.
+        try {
+            const resp = await this.$axios.get((process.env.API_HOST || '')+'/console/1.0/sign/access');
+            if ( resp != null && resp.data != null && resp.data.consoleBearer ) {
+                this.$store.commit('setConsoleBearer', resp.data.consoleBearer);
+                this.$store.commit('setUserAdmin', resp.data.admin);
+                await this.$auth.setUserToken(resp.data.consoleBearer);
+                this.$router.push('/front/');
+            }
+        } catch (err) {
+            // no walk-in available — normal login form
+        }
     }
 })
 

--- a/nuxt/console/pages/front/login.vue
+++ b/nuxt/console/pages/front/login.vue
@@ -196,6 +196,15 @@ export default Vue.extend({
         this.$store.commit('setConsoleBearer', '');
         this.$store.commit('setUserAdmin',false);
 
+        // Default the embedded ChirpStack UI to our primary tenant on a fresh
+        // session. ChirpStack keeps the active tenant in localStorage['tenantId'];
+        // seeding it here (config-driven, never hardcoded) makes a clean
+        // walk-in/login land on the configured tenant instead of whatever
+        // ChirpStack sorts first. An existing selection is left untouched.
+        if (this.$config.defaultTenant && !localStorage.getItem('tenantId')) {
+            localStorage.setItem('tenantId', this.$config.defaultTenant);
+        }
+
         // Cloudflare Access walk-in (buoy-services ADR-0002): behind the
         // tunnel, every request carries Cf-Access-Jwt-Assertion — try
         // exchanging it for a console session before showing the form.

--- a/src/main/java/eu/heliumiot/console/ConsoleConfig.java
+++ b/src/main/java/eu/heliumiot/console/ConsoleConfig.java
@@ -290,6 +290,13 @@ public class ConsoleConfig {
     @Value ("${helium.billing.vat.message9:}")
     private String heliumBillingVatMessage9;
 
+    @Value("${helium.invoice.recovered.packets:false}")
+    private boolean heliumInvoiceRecoveredPackets;
+
+
+    public boolean isHeliumInvoiceRecoveredPackets() {
+        return heliumInvoiceRecoveredPackets;
+    }
 
     public int getHeliumBillingDcPunishment() {
         return heliumBillingDcPunishment;
@@ -954,6 +961,20 @@ public class ConsoleConfig {
     @Value ("${helium.tenant.dc.alarm:10000}")
     private int heliumTenantDcAlarm;
 
+    @Value("${helium.logs.enable:false}")
+    private boolean heliumLogsEnable;
+
+    @Value("${helium.logs.gateway.list:}")
+    private String heliumLogsGatewayList;
+
+
+    public String getHeliumLogsGatewayList() {
+        return heliumLogsGatewayList;
+    }
+
+    public boolean isHeliumLogsEnable() {
+        return heliumLogsEnable;
+    }
 
     public boolean isStatReportEnable() {
         if (!statReportEnable.isEmpty()) {
@@ -995,5 +1016,42 @@ public class ConsoleConfig {
 
     public int getHeliumCacheDeviceStat() {
         return heliumCacheDeviceStat;
+    }
+
+    // ==============================
+    // Cloudflare Access Shim (walk-in SSO, buoy-services ADR-0002)
+    // ==============================
+    @Value ("${helium.cf.access.team.domain.default}")
+    private String cfAccessTeamDomainDefault;
+
+    @Value ("${helium.cf.access.team.domain:}")
+    private String cfAccessTeamDomainExternal;
+
+    @Value ("${helium.cf.access.audience.default}")
+    private String cfAccessAudienceDefault;
+
+    @Value ("${helium.cf.access.audience:}")
+    private String cfAccessAudienceExternal;
+
+    @Value ("${helium.cf.access.session.ms.default}")
+    private long cfAccessSessionMsDefault;
+
+    @Value ("${helium.cf.access.session.ms:0}")
+    private long cfAccessSessionMsExternal;
+
+    public String getCfAccessTeamDomain() {
+        if (!cfAccessTeamDomainExternal.isEmpty()) return cfAccessTeamDomainExternal;
+        return cfAccessTeamDomainDefault;
+    }
+
+    /** The Access application's aud tag; empty = Shim disabled. */
+    public String getCfAccessAudience() {
+        if (!cfAccessAudienceExternal.isEmpty()) return cfAccessAudienceExternal;
+        return cfAccessAudienceDefault;
+    }
+
+    public long getCfAccessSessionMs() {
+        if (cfAccessSessionMsExternal > 0) return cfAccessSessionMsExternal;
+        return cfAccessSessionMsDefault;
     }
 }

--- a/src/main/java/eu/heliumiot/console/ConsoleConfig.java
+++ b/src/main/java/eu/heliumiot/console/ConsoleConfig.java
@@ -1027,6 +1027,15 @@ public class ConsoleConfig {
     @Value ("${helium.cf.access.team.domain:}")
     private String cfAccessTeamDomainExternal;
 
+    // JWKS host — DIFFERENT label of the same team than the issuer above:
+    // tokens are stamped iss=team.domain (royal-waterfall) but signed by keys
+    // served only at this host (buoy-fish). See HANDOFF-access-jwks-vs-iss.
+    @Value ("${helium.cf.access.jwks.domain.default}")
+    private String cfAccessJwksDomainDefault;
+
+    @Value ("${helium.cf.access.jwks.domain:}")
+    private String cfAccessJwksDomainExternal;
+
     @Value ("${helium.cf.access.audience.default}")
     private String cfAccessAudienceDefault;
 
@@ -1051,6 +1060,13 @@ public class ConsoleConfig {
     public String getCfAccessTeamDomain() {
         if (!cfAccessTeamDomainExternal.isEmpty()) return cfAccessTeamDomainExternal;
         return cfAccessTeamDomainDefault;
+    }
+
+    /** Host serving the Access signing keys (JWKS) — see field comment; this
+     *  is intentionally NOT the same as the issuer/team domain. */
+    public String getCfAccessJwksDomain() {
+        if (!cfAccessJwksDomainExternal.isEmpty()) return cfAccessJwksDomainExternal;
+        return cfAccessJwksDomainDefault;
     }
 
     /** The Access application's aud tag; empty = Shim disabled. */

--- a/src/main/java/eu/heliumiot/console/ConsoleConfig.java
+++ b/src/main/java/eu/heliumiot/console/ConsoleConfig.java
@@ -1039,6 +1039,15 @@ public class ConsoleConfig {
     @Value ("${helium.cf.access.session.ms:0}")
     private long cfAccessSessionMsExternal;
 
+    // ChirpStack's api.secret (chirpstack.toml) — lets the Shim mint a
+    // ChirpStack user token for walk-in sessions (no password to run Login).
+    @Value ("${chirpstack.api.secret:}")
+    private String chirpstackApiSecret;
+
+    public String getChirpstackApiSecret() {
+        return chirpstackApiSecret;
+    }
+
     public String getCfAccessTeamDomain() {
         if (!cfAccessTeamDomainExternal.isEmpty()) return cfAccessTeamDomainExternal;
         return cfAccessTeamDomainDefault;

--- a/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
+++ b/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
@@ -93,7 +93,7 @@ public class SignInUpApi {
             // T&C re-acceptance surfaces on password login only
             r.setUserConditionChanged(false);
             prometeusService.addUserTotalLogin();
-            log.info("Access walk-in granted");
+            log.info("Access walk-in granted (admin={})", ex.admin());
             return new ResponseEntity<>(r, HttpStatus.OK);
         } catch (eu.heliumiot.console.service.AccessShimService.NoConsoleAccount x) {
             // cleared the wall, no account — login page falls back to the form
@@ -102,7 +102,7 @@ public class SignInUpApi {
             prometeusService.addApiTotalError();
             return new ResponseEntity<>(ActionResult.FORBIDDEN(), HttpStatus.FORBIDDEN);
         } catch (Exception x) {
-            log.warn("Access walk-in failed: " + x.getMessage());
+            log.warn("Access walk-in failed: {}", x.toString());
             prometeusService.addApiTotalError();
             return new ResponseEntity<>(ActionResult.BADREQUEST(), HttpStatus.BAD_REQUEST);
         } finally {

--- a/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
+++ b/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
@@ -58,6 +58,58 @@ public class SignInUpApi {
     @Autowired
     protected PrometeusService prometeusService;
 
+    @Autowired
+    protected eu.heliumiot.console.service.AccessShimService accessShimService;
+
+
+    @Operation(summary = "Cloudflare Access walk-in",
+            description = "Exchange the Cf-Access-Jwt-Assertion header (injected by"
+                    + " Cloudflare Access at the edge, buoy-services ADR-0002) for a"
+                    + " console bearer. Match-only: 404 when the verified email has no"
+                    + " console account — the login page then falls back to the normal"
+                    + " form. Walk-in sessions carry no chirpstack bearer (only the"
+                    + " chirpstack migration screen needs one; use password login for it).",
+            responses = {
+                    @ApiResponse(responseCode = "200", description= "Done", content = @Content(schema = @Schema(implementation = LoginRespItf.class))),
+                    @ApiResponse(responseCode = "403", description= "Forbidden", content = @Content(schema = @Schema(implementation = ActionResult.class))),
+                    @ApiResponse(responseCode = "404", description= "No console account", content = @Content(schema = @Schema(implementation = ActionResult.class)))
+            }
+    )
+    @RequestMapping(value="/access",
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            method= RequestMethod.GET)
+    public ResponseEntity<?> requestAccessWalkIn(
+            HttpServletRequest request
+    ) {
+        long startMs = Now.NowUtcMs();
+        try {
+            String accessJwt = request.getHeader("Cf-Access-Jwt-Assertion");
+            eu.heliumiot.console.service.AccessShimService.ExchangeResult ex =
+                    accessShimService.exchangeForConsoleBearer(accessJwt);
+            LoginRespItf r = new LoginRespItf();
+            r.setConsoleBearer(ex.consoleBearer());
+            r.setChirpstackBearer("");
+            r.setAdmin(ex.admin());
+            // T&C re-acceptance surfaces on password login only
+            r.setUserConditionChanged(false);
+            prometeusService.addUserTotalLogin();
+            log.info("Access walk-in granted");
+            return new ResponseEntity<>(r, HttpStatus.OK);
+        } catch (eu.heliumiot.console.service.AccessShimService.NoConsoleAccount x) {
+            // cleared the wall, no account — login page falls back to the form
+            return new ResponseEntity<>(ActionResult.NOTFOUND(), HttpStatus.NOT_FOUND);
+        } catch (eu.heliumiot.console.service.AccessJwtVerifier.InvalidAccessJwt x) {
+            prometeusService.addApiTotalError();
+            return new ResponseEntity<>(ActionResult.FORBIDDEN(), HttpStatus.FORBIDDEN);
+        } catch (Exception x) {
+            log.warn("Access walk-in failed: " + x.getMessage());
+            prometeusService.addApiTotalError();
+            return new ResponseEntity<>(ActionResult.BADREQUEST(), HttpStatus.BAD_REQUEST);
+        } finally {
+            prometeusService.addApiTotalTimeMs(startMs);
+        }
+    }
+
 
     @Operation(summary = "Sign-in endpoint",
             description = "Authenticate on back-end and in chirpstack, get both token",

--- a/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
+++ b/src/main/java/eu/heliumiot/console/api/SignInUpApi.java
@@ -88,7 +88,7 @@ public class SignInUpApi {
                     accessShimService.exchangeForConsoleBearer(accessJwt);
             LoginRespItf r = new LoginRespItf();
             r.setConsoleBearer(ex.consoleBearer());
-            r.setChirpstackBearer("");
+            r.setChirpstackBearer(ex.chirpstackBearer());
             r.setAdmin(ex.admin());
             // T&C re-acceptance surfaces on password login only
             r.setUserConditionChanged(false);

--- a/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
@@ -49,13 +49,27 @@ public class AccessJwtVerifier {
     }
 
     /**
+     * The Cloudflare Access JWKS (certs) endpoint for a team label. Kept
+     * deliberately separate from the issuer: on the buoy account the signing
+     * keys are served ONLY at the buoy-fish label, while every token is
+     * stamped with the (404-on-certs) royal-waterfall issuer. Deriving this
+     * URL from the issuer is the latent bug — see docs/HANDOFF-access-jwks-vs-iss.
+     */
+    static String certsUrl(String jwksDomain) {
+        return "https://" + jwksDomain + "/cdn-cgi/access/certs";
+    }
+
+    /**
      * Production wiring: remote JWKS with Nimbus' built-in caching and
      * rate-limiting, so Cloudflare key rotation is handled transparently.
+     * issuerDomain (the token's {@code iss}) and jwksDomain (where the signing
+     * keys live) are different labels of the SAME team on this account, so they
+     * are passed separately — never derive one from the other.
      */
-    public static AccessJwtVerifier forTeam(String teamDomain, String audience) throws Exception {
-        String iss = "https://" + teamDomain;
+    public static AccessJwtVerifier forTeam(String issuerDomain, String jwksDomain, String audience) throws Exception {
+        String iss = "https://" + issuerDomain;
         JWKSource<SecurityContext> remote = JWKSourceBuilder
-                .create(new URL(iss + "/cdn-cgi/access/certs"))
+                .create(new URL(certsUrl(jwksDomain)))
                 .retrying(true)
                 .build();
         return new AccessJwtVerifier(remote, iss, audience);

--- a/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessJwtVerifier.java
@@ -1,0 +1,87 @@
+package eu.heliumiot.console.service;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+import java.net.URL;
+import java.util.Set;
+
+/**
+ * Cryptographic core of the Cloudflare Access Shim (ADR-0002 in the
+ * buoy-services repo): validates the Cf-Access-Jwt-Assertion header that
+ * Access injects at the edge and surfaces the verified visitor email.
+ *
+ * Accepts exactly the tokens our Access application mints — RS256 signature
+ * against the team's JWKS, pinned issuer, pinned audience, unexpired, and
+ * carrying an email claim (service tokens authenticate without one and must
+ * NOT become console sessions). Everything else throws InvalidAccessJwt.
+ *
+ * The origin is tunnel-only (ADR-0001), so a forged header can't normally
+ * reach us — this check is defense in depth, priced at one RS256 verify.
+ */
+public class AccessJwtVerifier {
+
+    public static class InvalidAccessJwt extends Exception {
+        public InvalidAccessJwt(String message, Throwable cause) {
+            super(message, cause);
+        }
+        public InvalidAccessJwt(String message) {
+            super(message);
+        }
+    }
+
+    private final DefaultJWTProcessor<SecurityContext> processor;
+
+    public AccessJwtVerifier(JWKSource<SecurityContext> keys, String issuer, String audience) {
+        this.processor = new DefaultJWTProcessor<>();
+        this.processor.setJWSKeySelector(
+                new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keys));
+        this.processor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>(
+                audience,
+                new JWTClaimsSet.Builder().issuer(issuer).build(),
+                Set.of("exp", "email")));
+    }
+
+    /**
+     * Production wiring: remote JWKS with Nimbus' built-in caching and
+     * rate-limiting, so Cloudflare key rotation is handled transparently.
+     */
+    public static AccessJwtVerifier forTeam(String teamDomain, String audience) throws Exception {
+        String iss = "https://" + teamDomain;
+        JWKSource<SecurityContext> remote = JWKSourceBuilder
+                .create(new URL(iss + "/cdn-cgi/access/certs"))
+                .retrying(true)
+                .build();
+        return new AccessJwtVerifier(remote, iss, audience);
+    }
+
+    /**
+     * @return the verified email claim of a genuine, unexpired Access JWT
+     *         for our application.
+     * @throws InvalidAccessJwt for anything else — bad signature, wrong
+     *         issuer or audience, expired, missing email, garbage.
+     */
+    public String verifiedEmail(String token) throws InvalidAccessJwt {
+        if (token == null || token.isBlank()) {
+            throw new InvalidAccessJwt("no Access JWT presented");
+        }
+        try {
+            JWTClaimsSet claims = processor.process(token, null);
+            String email = claims.getStringClaim("email");
+            if (email == null || email.isBlank()) {
+                throw new InvalidAccessJwt("Access JWT carries no email (service token?)");
+            }
+            return email.toLowerCase();
+        } catch (InvalidAccessJwt e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidAccessJwt("Access JWT rejected: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/AccessShimService.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimService.java
@@ -1,0 +1,77 @@
+package eu.heliumiot.console.service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Orchestrates the Cloudflare Access walk-in (ADR-0002): exchange the
+ * Cf-Access-Jwt-Assertion header for the console's own session bearer.
+ *
+ * Flow: verify the Access JWT → take its email → match an active console
+ * user → mint that user's bearer. Provision only when there is no match
+ * (match-or-provision; accounting's Shim will be match-only). The crypto
+ * (AccessJwtVerifier) and token shape (ConsoleBearerMinter) live in their
+ * own pinned seams; this class is just the decision flow.
+ *
+ * The user store is abstracted behind {@link ConsoleUsers} so this logic is
+ * unit-testable without Spring or a database; the production binding lives
+ * in {@link AccessShimUsers}.
+ */
+public class AccessShimService {
+
+    /** A resolved console user: the id the bearer is minted for, its
+     *  per-user signing key, and whether it carries ROLE_ADMIN. */
+    public record ConsoleIdentity(String userid, Key signingKey, boolean admin) {}
+
+    /** The visitor cleared Access but has no console account. With a
+     *  match-only store this is the signal to fall back to the normal
+     *  login/signup page — not an error worth a stack trace. */
+    public static class NoConsoleAccount extends Exception {
+        public NoConsoleAccount(String message) {
+            super(message);
+        }
+    }
+
+    /** The console user store, as the Shim needs it. */
+    public interface ConsoleUsers {
+        /** The active console user for this email, or null if none. */
+        ConsoleIdentity findActiveByEmail(String email);
+        /** Create a console user for a verified Access email and return it. */
+        ConsoleIdentity provisionFromEmail(String email) throws Exception;
+    }
+
+    private final AccessJwtVerifier verifier;
+    private final ConsoleUsers users;
+    private final long ttlMs;
+
+    public AccessShimService(AccessJwtVerifier verifier, ConsoleUsers users, long ttlMs) {
+        this.verifier = verifier;
+        this.users = users;
+        this.ttlMs = ttlMs;
+    }
+
+    /** What the login page needs to establish the walk-in session. */
+    public record ExchangeResult(String consoleBearer, boolean admin) {}
+
+    /**
+     * @return a freshly minted console bearer for the Access-verified visitor
+     * @throws AccessJwtVerifier.InvalidAccessJwt if the header is not a
+     *         genuine Access JWT for this application
+     * @throws NoConsoleAccount when the visitor cleared Access but has no
+     *         console account (match-only store)
+     */
+    public ExchangeResult exchangeForConsoleBearer(String accessJwt) throws Exception {
+        String email = verifier.verifiedEmail(accessJwt);
+        ConsoleIdentity id = users.findActiveByEmail(email);
+        if (id == null) {
+            id = users.provisionFromEmail(email);
+        }
+        List<String> roles = id.admin()
+                ? List.of(UserService.ROLE_USER, UserService.ROLE_ADMIN)
+                : List.of(UserService.ROLE_USER);
+        String bearer = ConsoleBearerMinter.mint(
+                id.userid(), roles, new Date(System.currentTimeMillis() + ttlMs), id.signingKey());
+        return new ExchangeResult(bearer, id.admin());
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/AccessShimService.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimService.java
@@ -44,15 +44,20 @@ public class AccessShimService {
     private final AccessJwtVerifier verifier;
     private final ConsoleUsers users;
     private final long ttlMs;
+    private final String chirpstackApiSecret;
 
-    public AccessShimService(AccessJwtVerifier verifier, ConsoleUsers users, long ttlMs) {
+    public AccessShimService(AccessJwtVerifier verifier, ConsoleUsers users, long ttlMs,
+                             String chirpstackApiSecret) {
         this.verifier = verifier;
         this.users = users;
         this.ttlMs = ttlMs;
+        this.chirpstackApiSecret = chirpstackApiSecret;
     }
 
-    /** What the login page needs to establish the walk-in session. */
-    public record ExchangeResult(String consoleBearer, boolean admin) {}
+    /** What the login page needs to establish the walk-in session: the
+     *  console's own session token plus a ChirpStack user token (the SPA
+     *  talks to ChirpStack directly for device/gateway views). */
+    public record ExchangeResult(String consoleBearer, String chirpstackBearer, boolean admin) {}
 
     /**
      * @return a freshly minted console bearer for the Access-verified visitor
@@ -70,8 +75,13 @@ public class AccessShimService {
         List<String> roles = id.admin()
                 ? List.of(UserService.ROLE_USER, UserService.ROLE_ADMIN)
                 : List.of(UserService.ROLE_USER);
-        String bearer = ConsoleBearerMinter.mint(
-                id.userid(), roles, new Date(System.currentTimeMillis() + ttlMs), id.signingKey());
-        return new ExchangeResult(bearer, id.admin());
+        Date exp = new Date(System.currentTimeMillis() + ttlMs);
+        String consoleBearer = ConsoleBearerMinter.mint(
+                id.userid(), roles, exp, id.signingKey());
+        // The user's console id IS their ChirpStack user UUID (helium_user.userid
+        // == chirpstack user.id), so the same id mints the ChirpStack token.
+        String chirpstackBearer = ChirpstackBearerMinter.mint(
+                id.userid(), exp, chirpstackApiSecret);
+        return new ExchangeResult(consoleBearer, chirpstackBearer, id.admin());
     }
 }

--- a/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
@@ -27,11 +27,13 @@ public class AccessShimSetup {
             log.info("Access Shim disabled — helium.cf.access.audience is not set");
             audience = DISABLED_SENTINEL;
         } else {
-            log.info("Access Shim enabled for team {} (aud {}…)",
-                    config.getCfAccessTeamDomain(), audience.substring(0, Math.min(8, audience.length())));
+            log.info("Access Shim enabled for team {} (jwks {}, aud {}…)",
+                    config.getCfAccessTeamDomain(), config.getCfAccessJwksDomain(),
+                    audience.substring(0, Math.min(8, audience.length())));
         }
         AccessJwtVerifier verifier =
-                AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(), audience);
+                AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(),
+                        config.getCfAccessJwksDomain(), audience);
         if (config.getChirpstackApiSecret() == null || config.getChirpstackApiSecret().isBlank()) {
             log.warn("chirpstack.api.secret not set — walk-in sessions will carry no "
                     + "chirpstack bearer and device/gateway views will prompt for login");

--- a/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
@@ -1,0 +1,37 @@
+package eu.heliumiot.console.service;
+
+import eu.heliumiot.console.ConsoleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Access Shim from configuration. When no audience is configured
+ * the bean still exists but is built around a sentinel audience no real
+ * token carries — every exchange is rejected, i.e. the Shim is disabled
+ * without any conditional-bean machinery.
+ */
+@Configuration
+public class AccessShimSetup {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private static final String DISABLED_SENTINEL = "access-shim-disabled";
+
+    @Bean
+    public AccessShimService accessShimService(ConsoleConfig config, AccessShimUsers users)
+            throws Exception {
+        String audience = config.getCfAccessAudience();
+        if (audience == null || audience.isBlank()) {
+            log.info("Access Shim disabled — helium.cf.access.audience is not set");
+            audience = DISABLED_SENTINEL;
+        } else {
+            log.info("Access Shim enabled for team {} (aud {}…)",
+                    config.getCfAccessTeamDomain(), audience.substring(0, Math.min(8, audience.length())));
+        }
+        AccessJwtVerifier verifier =
+                AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(), audience);
+        return new AccessShimService(verifier, users, config.getCfAccessSessionMs());
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimSetup.java
@@ -32,6 +32,11 @@ public class AccessShimSetup {
         }
         AccessJwtVerifier verifier =
                 AccessJwtVerifier.forTeam(config.getCfAccessTeamDomain(), audience);
-        return new AccessShimService(verifier, users, config.getCfAccessSessionMs());
+        if (config.getChirpstackApiSecret() == null || config.getChirpstackApiSecret().isBlank()) {
+            log.warn("chirpstack.api.secret not set — walk-in sessions will carry no "
+                    + "chirpstack bearer and device/gateway views will prompt for login");
+        }
+        return new AccessShimService(verifier, users, config.getCfAccessSessionMs(),
+                config.getChirpstackApiSecret());
     }
 }

--- a/src/main/java/eu/heliumiot/console/service/AccessShimUsers.java
+++ b/src/main/java/eu/heliumiot/console/service/AccessShimUsers.java
@@ -1,0 +1,44 @@
+package eu.heliumiot.console.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Production user store for the Access Shim — MATCH-ONLY (2026-06-12):
+ * a console account is a billing entity (ChirpStack tenant, DC-burn
+ * accountability), so accounts come only from the deliberate signup flow,
+ * which itself lives behind the Access Members wall. The Shim signs in
+ * existing users; it never creates one.
+ */
+@Component
+public class AccessShimUsers implements AccessShimService.ConsoleUsers {
+
+    private final UserCacheService userCacheService;
+    private final UserService userService;
+
+    @Autowired
+    public AccessShimUsers(UserCacheService userCacheService, UserService userService) {
+        this.userCacheService = userCacheService;
+        this.userService = userService;
+    }
+
+    @Override
+    public AccessShimService.ConsoleIdentity findActiveByEmail(String email) {
+        UserCacheService.UserCacheElement u = userCacheService.getUserByUsername(email);
+        if (u == null || u.user == null || !u.user.isActive() || u.heliumUser == null) {
+            return null;
+        }
+        return new AccessShimService.ConsoleIdentity(
+                u.heliumUser.getUserid(),
+                userService.generateKeyForUser(u.heliumUser),
+                u.user.isAdmin());
+    }
+
+    @Override
+    public AccessShimService.ConsoleIdentity provisionFromEmail(String email)
+            throws AccessShimService.NoConsoleAccount {
+        throw new AccessShimService.NoConsoleAccount(
+                "no console account for " + email
+                + " — accounts are created via the signup flow (match-only Shim)");
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/ChirpstackBearerMinter.java
+++ b/src/main/java/eu/heliumiot/console/service/ChirpstackBearerMinter.java
@@ -1,0 +1,37 @@
+package eu.heliumiot.console.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * Mints a ChirpStack user-login JWT without a password, so the Access Shim
+ * can hand the console SPA a working chirpstackBearer (the second token the
+ * fork needs, alongside the consoleBearer).
+ *
+ * Shape pinned to ChirpStack v4.11.0 (AuthClaim::new_for_user): HS256 over
+ * {aud:"chirpstack", iss:"chirpstack", sub:<user-uuid>, typ:"user", exp},
+ * signed with the RAW api.secret bytes (ChirpStack does
+ * conf.api.secret.as_ref(), i.e. the secret string's UTF-8 bytes — NOT
+ * base64-decoded). Claims are set individually so `aud` serializes as a
+ * string; jjwt's audience builder would emit an array, which ChirpStack's
+ * `aud: String` rejects. Verified live against InternalService/Profile.
+ */
+public final class ChirpstackBearerMinter {
+
+    private ChirpstackBearerMinter() {}
+
+    public static String mint(String userId, Date expiration, String apiSecret) {
+        return Jwts.builder()
+                .header().add("typ", "JWT").and()
+                .claim("aud", "chirpstack")
+                .claim("iss", "chirpstack")
+                .claim("sub", userId)
+                .claim("typ", "user")
+                .expiration(expiration)
+                .signWith(Keys.hmacShaKeyFor(apiSecret.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/ConsoleBearerMinter.java
+++ b/src/main/java/eu/heliumiot/console/service/ConsoleBearerMinter.java
@@ -1,0 +1,40 @@
+package eu.heliumiot.console.service;
+
+import io.jsonwebtoken.Jwts;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Mints the console's own session token (the "consoleBearer", HS512) in the
+ * one canonical shape JWTAuthorizationFilter expects: subject in both the
+ * JWS header and the claims, a roles array, and an expiration, signed with
+ * the caller's per-user key (see UserService.generateKeyForUser).
+ *
+ * Extracted from UserService.verifyUserLogin so the password-login path and
+ * the Cloudflare Access Shim mint byte-identical tokens — neither can drift
+ * from what the auth filter accepts.
+ */
+public final class ConsoleBearerMinter {
+
+    private ConsoleBearerMinter() {}
+
+    public static String mint(String userid, List<String> roles, Date expiration, Key signingKey) {
+        io.jsonwebtoken.Claims claims = Jwts.claims()
+                .subject(userid)
+                .expiration(expiration)
+                .add("roles", roles)
+                .build();
+
+        return Jwts.builder()
+                .header().add("typ", "JWT")
+                .add("sub", userid)
+                .and()
+                .claims().empty().add(claims)
+                .and()
+                .expiration(expiration)
+                .signWith(signingKey)
+                .compact();
+    }
+}

--- a/src/main/java/eu/heliumiot/console/service/UserService.java
+++ b/src/main/java/eu/heliumiot/console/service/UserService.java
@@ -228,8 +228,10 @@ public class UserService {
         }
         */
         if ( ! safetyService.trustUserSignUp(req,adr) ) {
+            log.warn("Refused registration for {} from {} untrusted", req.getUsername(), adr);
             r.setErrorMessage("success");
             Tools.sleep(8+((new Random().nextInt()) % 7));
+            return r;
         }
 
 
@@ -576,22 +578,13 @@ public class UserService {
             roles.add(ROLE_USER);
             if ( u.user.isAdmin() ) roles.add(ROLE_ADMIN);
 
-            // generate the console jwt
-            io.jsonwebtoken.Claims claims = Jwts.claims()
-                .subject(u.heliumUser.getUserid())
-                .expiration(new Date(cExpiration))
-                .add("roles", roles)
-                .build();
-
-            String token = Jwts.builder()
-                .header().add("typ","JWT")
-                .add("sub",u.heliumUser.getUserid())
-                .and()
-                .claims().empty().add(claims)
-                .and()
-                .expiration(new Date(cExpiration))
-                .signWith(this.generateKeyForUser(u.heliumUser))
-                .compact();
+            // generate the console jwt (shape shared with the Access Shim)
+            String token = ConsoleBearerMinter.mint(
+                u.heliumUser.getUserid(),
+                roles,
+                new Date(cExpiration),
+                this.generateKeyForUser(u.heliumUser)
+            );
 
             r.setConsoleBearer(token);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,6 +147,11 @@ helium.stats.report.enable.default=true
 # Cloudflare Access Shim (walk-in SSO, buoy-services ADR-0002).
 # audience = the Access application's aud tag; empty disables the Shim
 # (the /sign/access endpoint then rejects every exchange).
+# team.domain = the token issuer (iss). jwks.domain = the host that actually
+# serves the signing keys. On the buoy account these are two labels of one
+# team and must differ: royal-waterfall's /certs is 404, buoy-fish's is 200.
+# See docs/HANDOFF-access-jwks-vs-iss.md.
 helium.cf.access.team.domain.default=royal-waterfall-9e8e.cloudflareaccess.com
+helium.cf.access.jwks.domain.default=buoy-fish.cloudflareaccess.com
 helium.cf.access.audience.default=
 helium.cf.access.session.ms.default=86400000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.main.register-shutdown-hook=true
 #    spring.jpa.properties.hibernate.format_sql=true
 helium.allows.signup.default=false
 helium.allows.activation.default=true
-helium.version=1.11.0
+helium.version=1.12.0
 
 ## Stripe - test key by default
 helium.stripe.key.private.default=sk_test_VePHdqKTYQjKNInc7u56JBrQ
@@ -144,3 +144,9 @@ helium.testdevice.eui.default=
 
 # Stats
 helium.stats.report.enable.default=true
+# Cloudflare Access Shim (walk-in SSO, buoy-services ADR-0002).
+# audience = the Access application's aud tag; empty disables the Shim
+# (the /sign/access endpoint then rejects every exchange).
+helium.cf.access.team.domain.default=royal-waterfall-9e8e.cloudflareaccess.com
+helium.cf.access.audience.default=
+helium.cf.access.session.ms.default=86400000

--- a/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
@@ -113,4 +113,15 @@ public class AccessJwtVerifierTest {
         assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(""));
         assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(null));
     }
+
+    @Test
+    void certsUrlFollowsJwksDomainNotIssuer() {
+        // This Cloudflare account has two labels for one team: tokens are
+        // stamped iss=royal-waterfall-9e8e… (whose /certs is 404), but are
+        // signed by keys served ONLY at buoy-fish… So the JWKS/certs URL must
+        // be built from the jwks domain, independently of the issuer domain.
+        assertEquals(
+                "https://buoy-fish.cloudflareaccess.com/cdn-cgi/access/certs",
+                AccessJwtVerifier.certsUrl("buoy-fish.cloudflareaccess.com"));
+    }
 }

--- a/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessJwtVerifierTest.java
@@ -1,0 +1,116 @@
+package eu.heliumiot.console.service;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The Access Shim's cryptographic core (ADR-0002, buoy-services repo):
+ * Cloudflare Access has authenticated the visitor at the edge and injected
+ * Cf-Access-Jwt-Assertion. The verifier's contract is to accept exactly the
+ * tokens our Access application mints — right signature, right issuer,
+ * right audience, unexpired — and surface the verified email; everything
+ * else is rejected. The origin is tunnel-only, but we verify anyway:
+ * defense in depth costs one RS256 check.
+ */
+public class AccessJwtVerifierTest {
+
+    static final String ISSUER = "https://royal-waterfall-9e8e.cloudflareaccess.com";
+    static final String AUDIENCE = "db81f6eda2501216aaaabbbbccccdddd0000111122223333aaaabbbbcccc0000";
+
+    static RSAKey teamKey;       // stands in for the Cloudflare team key
+    static RSAKey strangerKey;   // a valid RSA key Access never used
+    static AccessJwtVerifier verifier;
+
+    @BeforeAll
+    static void keys() throws Exception {
+        teamKey = new RSAKeyGenerator(2048).keyID("team-key-1").generate();
+        strangerKey = new RSAKeyGenerator(2048).keyID("stranger").generate();
+        verifier = new AccessJwtVerifier(
+                new ImmutableJWKSet<>(new JWKSet(teamKey.toPublicJWK())),
+                ISSUER,
+                AUDIENCE);
+    }
+
+    static String token(RSAKey key, String iss, String aud, String email, Date exp) throws Exception {
+        JWTClaimsSet.Builder claims = new JWTClaimsSet.Builder()
+                .issuer(iss)
+                .audience(aud)
+                .subject("user-uuid")
+                .expirationTime(exp)
+                .issueTime(new Date());
+        if (email != null) claims.claim("email", email);
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256)
+                        .keyID(key.getKeyID())
+                        .type(JOSEObjectType.JWT)
+                        .build(),
+                claims.build());
+        jwt.sign(new RSASSASigner(key));
+        return jwt.serialize();
+    }
+
+    static Date in(long minutes) {
+        return new Date(System.currentTimeMillis() + minutes * 60_000L);
+    }
+
+    @Test
+    void validTokenYieldsItsEmail() throws Exception {
+        String t = token(teamKey, ISSUER, AUDIENCE, "jameson@buoy.fish", in(5));
+        assertEquals("jameson@buoy.fish", verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void wrongAudienceIsRejected() throws Exception {
+        // a Member's perfectly valid JWT for a DIFFERENT Access app
+        String t = token(teamKey, ISSUER, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "jameson@buoy.fish", in(5));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void wrongIssuerIsRejected() throws Exception {
+        String t = token(teamKey, "https://some-other-team.cloudflareaccess.com", AUDIENCE, "jameson@buoy.fish", in(5));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void expiredTokenIsRejected() throws Exception {
+        String t = token(teamKey, ISSUER, AUDIENCE, "jameson@buoy.fish", in(-5));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void signatureFromUnknownKeyIsRejected() throws Exception {
+        String t = token(strangerKey, ISSUER, AUDIENCE, "jameson@buoy.fish", in(5));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void missingEmailClaimIsRejected() throws Exception {
+        // service tokens authenticate without an email — the Shim must not
+        // mint a console session for them
+        String t = token(teamKey, ISSUER, AUDIENCE, null, in(5));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(t));
+    }
+
+    @Test
+    void garbageIsRejected() {
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail("not-a-jwt"));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(""));
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> verifier.verifiedEmail(null));
+    }
+}

--- a/src/test/java/eu/heliumiot/console/service/AccessShimServiceTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessShimServiceTest.java
@@ -1,0 +1,96 @@
+package eu.heliumiot.console.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.Key;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The Shim's orchestration (ADR-0002): a verified Access email becomes a
+ * console session. Match an existing console user and mint their bearer;
+ * provision only when there's no match. Crypto (AccessJwtVerifier) and the
+ * token shape (ConsoleBearerMinter) are pinned elsewhere — here we pin the
+ * decision flow, with the user store and verifier mocked.
+ */
+public class AccessShimServiceTest {
+
+    static final long TTL = 3_600_000L;
+    static final Key MEMBER_KEY = Keys.hmacShaKeyFor(new byte[64]);
+
+    AccessJwtVerifier verifier;
+    AccessShimService.ConsoleUsers users;
+    AccessShimService shim;
+
+    @BeforeEach
+    void setup() {
+        verifier = mock(AccessJwtVerifier.class);
+        users = mock(AccessShimService.ConsoleUsers.class);
+        shim = new AccessShimService(verifier, users, TTL);
+    }
+
+    List<String> rolesOf(String bearer) {
+        Claims c = Jwts.parser().verifyWith((javax.crypto.SecretKey) MEMBER_KEY)
+                .build().parseSignedClaims(bearer).getPayload();
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) c.get("roles");
+        return roles;
+    }
+
+    String subjectOf(String bearer) {
+        return Jwts.parser().verifyWith((javax.crypto.SecretKey) MEMBER_KEY)
+                .build().parseSignedClaims(bearer).getPayload().getSubject();
+    }
+
+    @Test
+    void existingMemberGetsABearerForTheirOwnId() throws Exception {
+        when(verifier.verifiedEmail("access-jwt")).thenReturn("jameson@buoy.fish");
+        when(users.findActiveByEmail("jameson@buoy.fish"))
+                .thenReturn(new AccessShimService.ConsoleIdentity("uuid-jameson", MEMBER_KEY, false));
+
+        AccessShimService.ExchangeResult r = shim.exchangeForConsoleBearer("access-jwt");
+
+        assertEquals("uuid-jameson", subjectOf(r.consoleBearer()));
+        assertEquals(List.of("ROLE_USER"), rolesOf(r.consoleBearer()));
+        assertFalse(r.admin());
+        verify(users, never()).provisionFromEmail(anyString());
+    }
+
+    @Test
+    void adminIdentityCarriesTheAdminRole() throws Exception {
+        when(verifier.verifiedEmail("access-jwt")).thenReturn("jameson@buoy.fish");
+        when(users.findActiveByEmail("jameson@buoy.fish"))
+                .thenReturn(new AccessShimService.ConsoleIdentity("uuid-jameson", MEMBER_KEY, true));
+
+        AccessShimService.ExchangeResult r = shim.exchangeForConsoleBearer("access-jwt");
+        assertEquals(List.of("ROLE_USER", "ROLE_ADMIN"), rolesOf(r.consoleBearer()));
+        assertTrue(r.admin());
+    }
+
+    @Test
+    void unknownEmailProvisionsThenMints() throws Exception {
+        when(verifier.verifiedEmail("access-jwt")).thenReturn("newbie@buoy.fish");
+        when(users.findActiveByEmail("newbie@buoy.fish")).thenReturn(null);
+        when(users.provisionFromEmail("newbie@buoy.fish"))
+                .thenReturn(new AccessShimService.ConsoleIdentity("uuid-new", MEMBER_KEY, false));
+
+        AccessShimService.ExchangeResult r = shim.exchangeForConsoleBearer("access-jwt");
+
+        assertEquals("uuid-new", subjectOf(r.consoleBearer()));
+        verify(users).provisionFromEmail("newbie@buoy.fish");
+    }
+
+    @Test
+    void anInvalidAccessJwtNeverTouchesTheUserStore() throws Exception {
+        when(verifier.verifiedEmail("bad")).thenThrow(new AccessJwtVerifier.InvalidAccessJwt("nope"));
+
+        assertThrows(AccessJwtVerifier.InvalidAccessJwt.class, () -> shim.exchangeForConsoleBearer("bad"));
+        verifyNoInteractions(users);
+    }
+}

--- a/src/test/java/eu/heliumiot/console/service/AccessShimUsersTest.java
+++ b/src/test/java/eu/heliumiot/console/service/AccessShimUsersTest.java
@@ -1,0 +1,75 @@
+package eu.heliumiot.console.service;
+
+import eu.heliumiot.console.jpa.db.HeliumUser;
+import eu.heliumiot.console.jpa.db.User;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Production binding of the Shim's user store. Console is MATCH-ONLY
+ * (decided 2026-06-12): a console account is a billing entity — ChirpStack
+ * tenant with DC-burn accountability — so accounts are created only through
+ * the deliberate signup flow (which lives behind the Access wall), never
+ * auto-provisioned from an edge header.
+ */
+public class AccessShimUsersTest {
+
+    UserCacheService cache;
+    UserService userService;
+    AccessShimUsers users;
+
+    @BeforeEach
+    void setup() {
+        cache = mock(UserCacheService.class);
+        userService = mock(UserService.class);
+        users = new AccessShimUsers(cache, userService);
+    }
+
+    UserCacheService.UserCacheElement element(String userid, boolean active, boolean admin) {
+        UserCacheService.UserCacheElement e = cache.new UserCacheElement();
+        e.user = new User();
+        e.user.setActive(active);
+        e.user.setAdmin(admin);
+        e.heliumUser = new HeliumUser();
+        e.heliumUser.setUserid(userid);
+        return e;
+    }
+
+    @Test
+    void activeUserResolvesWithKeyAndAdminFlag() {
+        UserCacheService.UserCacheElement e = element("uuid-1", true, true);
+        when(cache.getUserByUsername("jameson@buoy.fish")).thenReturn(e);
+        when(userService.generateKeyForUser(e.heliumUser))
+                .thenReturn(Keys.hmacShaKeyFor(new byte[64]));
+
+        AccessShimService.ConsoleIdentity id = users.findActiveByEmail("jameson@buoy.fish");
+
+        assertNotNull(id);
+        assertEquals("uuid-1", id.userid());
+        assertTrue(id.admin());
+        assertNotNull(id.signingKey());
+    }
+
+    @Test
+    void unknownEmailResolvesToNull() {
+        when(cache.getUserByUsername("ghost@buoy.fish")).thenReturn(null);
+        assertNull(users.findActiveByEmail("ghost@buoy.fish"));
+    }
+
+    @Test
+    void inactiveUserResolvesToNull() {
+        when(cache.getUserByUsername("gone@buoy.fish")).thenReturn(element("uuid-2", false, false));
+        assertNull(users.findActiveByEmail("gone@buoy.fish"));
+    }
+
+    @Test
+    void provisioningIsRefused_consoleIsMatchOnly() {
+        assertThrows(AccessShimService.NoConsoleAccount.class,
+                () -> users.provisionFromEmail("new@buoy.fish"));
+        verifyNoInteractions(userService);
+    }
+}

--- a/src/test/java/eu/heliumiot/console/service/ConsoleBearerMinterTest.java
+++ b/src/test/java/eu/heliumiot/console/service/ConsoleBearerMinterTest.java
@@ -1,0 +1,68 @@
+package eu.heliumiot.console.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The console bearer is minted in exactly one shape today, inline in
+ * UserService.verifyUserLogin. The Access Shim must mint an IDENTICAL token
+ * — same subject, roles, expiration, signing key — so the existing
+ * JWTAuthorizationFilter accepts it unchanged. This pins that shape in a
+ * pure seam both call sites share, so the two can never drift.
+ */
+public class ConsoleBearerMinterTest {
+
+    /** A 64-byte HMAC key like generateKeyForUser produces. */
+    static Key key(byte fill) {
+        byte[] b = new byte[64];
+        java.util.Arrays.fill(b, fill);
+        return Keys.hmacShaKeyFor(b);
+    }
+
+    @Test
+    void mintedTokenParsesBackWithItsClaims() {
+        Key k = key((byte) 0x5a);
+        Date exp = new Date(System.currentTimeMillis() + 3_600_000L);
+
+        String token = ConsoleBearerMinter.mint("user-uuid-123", List.of("ROLE_USER", "ROLE_ADMIN"), exp, k);
+
+        Claims claims = Jwts.parser().verifyWith((javax.crypto.SecretKey) k)
+                .build().parseSignedClaims(token).getPayload();
+        assertEquals("user-uuid-123", claims.getSubject());
+        assertEquals(List.of("ROLE_USER", "ROLE_ADMIN"), claims.get("roles"));
+        // second-resolution equality — JWT exp is unix seconds
+        assertEquals(exp.getTime() / 1000, claims.getExpiration().getTime() / 1000);
+    }
+
+    @Test
+    void subjectIsAlsoInTheHeader() {
+        // JWTAuthorizationFilter reads `sub` from the JWS *header* to locate
+        // the per-user key before it can verify the signature — so the
+        // header sub must be present and match.
+        Key k = key((byte) 0x33);
+        String token = ConsoleBearerMinter.mint("abc", List.of("ROLE_USER"),
+                new Date(System.currentTimeMillis() + 60_000L), k);
+        String headerB64 = token.substring(0, token.indexOf('.'));
+        String header = new String(java.util.Base64.getUrlDecoder().decode(headerB64));
+        assertTrue(header.contains("\"sub\":\"abc\""), "header was: " + header);
+    }
+
+    @Test
+    void aDifferentKeyDoesNotVerify() {
+        String token = ConsoleBearerMinter.mint("u", List.of("ROLE_USER"),
+                new Date(System.currentTimeMillis() + 60_000L), key((byte) 0x01));
+        assertThrows(Exception.class, () ->
+                Jwts.parser().verifyWith((javax.crypto.SecretKey) key((byte) 0x02))
+                        .build().parseSignedClaims(token));
+    }
+}


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE AS-IS.** This branch has diverged from `main` in **both directions**. Merging it would revert `main`'s history (including the Access-shim PRs #1–6 and the upstream sync in #8) and clobber live work. It needs a **reconciliation**, not a merge — see the plan below.

## What this PR is
A faithful capture of the code **currently running on prod** (`console.buoy.fish`, EC2 `54.174.228.229`), branch `buoy/mqtt-auth-and-expose` @ `02e9865`. Pushed so it's reviewable and so **`85db91f` is no longer box-local-only** (it had never been pushed to GitHub — one disk failure from gone).

## Box-unique commits (live in prod, absent from `main`)
- `83b4ab2` expose MQTT broker w/ auth for external gateway access
- `7ec304d` MQTT auth setup in `makeiteasy.sh` installer
- `625688a` MQTT auth placeholders + Redis stream tuning
- `0974204` MQTT auth creds for `mosquitto_exporter`
- `85db91f` mosquitto: bind-mount `password_file`/`acl.conf` (uplink-outage fix) — **was unpushed**
- `82327b1` correct ownership on Grafana/Prometheus data dirs

## Why it's a reconciliation, not a merge
Both lineages independently implemented **MQTT-auth-for-external-access**:
- **this branch (prod):** buoy's `83b4ab2` + `7ec304d`
- **`main`:** upstream's `8ff3c4f` "Common - add MQTT authentication with ACLs for external access" + a body of MQTT reconnection/internal-listener work

`main` is also **ahead** of prod: the clean Access-shim slices #1–6 and upstream "Common -" commits; `MqttLoRaListener.java` is newer on `main` (1208 lines vs 1086 here). So neither side is a superset — someone must decide which MQTT-auth implementation is canonical and merge the runtime config (mosquitto bind-mounts, exporter creds, gateway tomls).

## Next step
A fresh agent runs `/code-review` on this branch then the reconciliation/merge process — see `docs/PLAN-box-branch-reconciliation.md`. Related: PR #8 (upstream sync + npm, prod untouched), `docs/HANDOFF-upstream-sync-evaluation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
